### PR TITLE
DO NOT MERGE: Try to investigate why builds are not reproducible

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,8 @@ on:
       - master
 
 env:
-  RUSTFLAGS: -Dwarnings --remap-path-prefix /home/runner=/home/redacted
+  RUSTFLAGS: -Dwarnings
+  RUSTC_BOOTSTRAP: 1
 
 jobs:
   check:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 ]
 
 [profile.release]
-opt-level = "s"
+opt-level = 0
 strip = "none"
 lto = true
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [profile.release]
-opt-level = 0
+opt-level = "s"
 strip = "none"
 lto = true
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["trim-paths"]
+
 [workspace]
 resolver = "2"
 members = [
@@ -11,3 +13,4 @@ lto = "off"
 panic = "abort"
 incremental = false
 codegen-units = 1
+trim-paths = "all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 [profile.release]
 opt-level = 0
 strip = "none"
-lto = "off"
+lto = true
 panic = "abort"
 incremental = false
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [profile.release]
 opt-level = 0
 strip = "none"
-lto = true
+lto = "off"
 panic = "abort"
 incremental = false
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [profile.release]
 opt-level = "s"
-strip = "symbols"
+strip = "none"
 lto = true
 panic = "abort"
 incremental = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 
 [profile.release]
 opt-level = "s"
-strip = "none"
+strip = "symbols"
 lto = true
 panic = "abort"
 incremental = false

--- a/pgpvis-core/Cargo.toml
+++ b/pgpvis-core/Cargo.toml
@@ -20,4 +20,4 @@ wasm-bindgen = "0.2.100"
 insta = { version = "1.42.2", features = ["yaml"] }
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+wasm-opt = ["-O"]

--- a/pgpvis-core/Cargo.toml
+++ b/pgpvis-core/Cargo.toml
@@ -20,4 +20,4 @@ wasm-bindgen = "0.2.100"
 insta = { version = "1.42.2", features = ["yaml"] }
 
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = ["-O"]
+wasm-opt = false

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -20,6 +20,9 @@ echo "Building $dist_name"
 echo "============================================================"
 echo "Rust toolchain:"
 rustup show -v
+echo ""
+echo "rustc version:"
+rustc --version --verbose
 echo "============================================================"
 
 mkdir -p "$dist_dir"


### PR DESCRIPTION
It seems that builds are already reproducible if on the same system (e.g., compare [this build](https://github.com/shniubobo/pgpvis/actions/runs/14624566904) and [this build](https://github.com/shniubobo/pgpvis/actions/runs/14625784303), which produced the same `wasm`).

However, what I am getting on my local machine is different from what is produced by the CI. After converting the `wasm` to `wat` and doing a `diff`, I have noticed several differences between the files.

One significant difference is that, on my local machine, an additional function is present in the `wat`:

```wat
(type (;36;) (func (param i64) (result i32)))
```

```wat
func (;677;) (type 36) (param i64) (result i32)
```

After turning off `wasm-opt`, I can see this function is (by searching for the function signature; there is only one function that takes an `i64` and returns an `i32`):

```wat
(type (;51;) (func (param i64) (result i32)))
```

```wat
func $anyhow::error::<impl_core::convert::From<E>_for_anyhow::Error>::from::h031add9f20a57a25 (type 51) (param i64) (result i32)
```
..., and a search in the `wat` file shows that it is referenced 488 times in total, which makes me wonder why the CI version does not need this function.

Therefore, I am turning off `wasm-opt` on the CI too so that I can compare the un-optimized `wat` files.