### PR TITLE
Fix error when `InputTab` is empty

### DIFF
--- a/pgpvis-ui/__mocks__/pgpvis-core.ts
+++ b/pgpvis-ui/__mocks__/pgpvis-core.ts
@@ -1,3 +1,13 @@
+export function parse(
+  _options: ParseOptions,
+  message: Uint8Array,
+): ParseOutput {
+  if (message.length === 0) {
+    throw new Error("failed to read message");
+  }
+  return new ParseOutput(new Uint8Array(1), [new Node("1")]);
+}
+
 export class Node {
   readonly text: string;
   readonly children: Node[];
@@ -15,6 +25,12 @@ export class Node {
     this.offset = offset;
     this.length = length;
   }
+
+  public free() {}
+}
+
+export class ParseOptions {
+  public constructor(public dearmor: boolean) {}
 
   public free() {}
 }

--- a/pgpvis-ui/eslint.config.js
+++ b/pgpvis-ui/eslint.config.js
@@ -21,6 +21,21 @@ export default typescriptEslint.config(
         parser: typescriptEslint.parser,
       },
     },
+    rules: {
+      // https://typescript-eslint.io/rules/no-unused-vars/
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
   },
   eslintConfigPrettier,
 );

--- a/pgpvis-ui/src/tabs/InputTab.test.ts
+++ b/pgpvis-ui/src/tabs/InputTab.test.ts
@@ -1,0 +1,65 @@
+import { mount, type VueWrapper } from "@vue/test-utils";
+
+import { Node } from "@mocks/pgpvis-core";
+import InputTab from "./InputTab.vue";
+
+vi.mock("pgpvis-core");
+
+let input_tab: VueWrapper;
+
+beforeEach(() => {
+  input_tab = mount(InputTab);
+});
+
+test("with message, emit non-empty values on click", async () => {
+  await input_tab.get("textarea").setValue("foo");
+  await input_tab.get("button").trigger("click");
+
+  expect(input_tab.emitted("update-hex-view")).toHaveLength(1);
+  expect(input_tab.emitted("update-packets")).toHaveLength(1);
+  // Values defined in `@mocks/pgpvis-core`
+  expect(input_tab.emitted("update-hex-view")![0]).toStrictEqual([
+    new Uint8Array(1),
+  ]);
+  expect(input_tab.emitted("update-packets")![0]).toStrictEqual([
+    [new Node("1")],
+  ]);
+});
+
+test("without message, emit empty values on click", async () => {
+  await input_tab.get("button").trigger("click");
+
+  expect(input_tab.emitted("update-hex-view")).toHaveLength(1);
+  expect(input_tab.emitted("update-packets")).toHaveLength(1);
+  // Values defined in `@mocks/pgpvis-core`
+  expect(input_tab.emitted("update-hex-view")![0]).toStrictEqual([
+    new Uint8Array(0),
+  ]);
+  expect(input_tab.emitted("update-packets")![0]).toStrictEqual([[]]);
+});
+
+test("first with message, and then with no message", async () => {
+  await input_tab.get("textarea").setValue("foo");
+  await input_tab.get("button").trigger("click");
+
+  expect(input_tab.emitted("update-hex-view")).toHaveLength(1);
+  expect(input_tab.emitted("update-packets")).toHaveLength(1);
+  // Values defined in `@mocks/pgpvis-core`
+  expect(input_tab.emitted("update-hex-view")![0]).toStrictEqual([
+    new Uint8Array(1),
+  ]);
+  expect(input_tab.emitted("update-packets")![0]).toStrictEqual([
+    [new Node("1")],
+  ]);
+
+  await input_tab.get("textarea").setValue("");
+  await input_tab.get("button").trigger("click");
+
+  expect(input_tab.emitted("update-hex-view")).toHaveLength(2);
+  expect(input_tab.emitted("update-packets")).toHaveLength(2);
+  // Values defined in `@mocks/pgpvis-core`
+  expect(input_tab.emitted("update-hex-view")![1]).toStrictEqual([
+    new Uint8Array(0),
+  ]);
+  expect(input_tab.emitted("update-packets")![1]).toStrictEqual([[]]);
+});

--- a/pgpvis-ui/src/tabs/InputTab.vue
+++ b/pgpvis-ui/src/tabs/InputTab.vue
@@ -12,6 +12,11 @@ const emit = defineEmits<{
 }>();
 
 function do_parse() {
+  if (message.value === "") {
+    emit("update-hex-view", new Uint8Array());
+    emit("update-packets", []);
+    return;
+  }
   const encoded_message = new TextEncoder().encode(message.value);
   // TODO: Allow users to choose whether to dearmor or not.
   const parse_options = new ParseOptions(true);


### PR DESCRIPTION
Sending an empty message to `core` results in `Error::Read`, so we need to special-case empty messages.

Also added test cases for `InputTab`, which were missing in the last release.