### PR TITLE
Extract binary dependency on `wasm-bindgen-cli` to a seperate crate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,10 @@ version: 2
 updates:
   - package-ecosystem: cargo
     directories:
-      - "**/*"
+      # Do NOT use "**/*", or `/wasm-bindgen-cli` will be included,
+      # which breaks dependabot.
+      - "/"
+      - "/pgpvis-core"
     schedule:
       interval: weekly
     # Stop dependabot from spamming

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,7 +1718,6 @@ dependencies = [
  "serde_repr",
  "thiserror 2.0.12",
  "wasm-bindgen",
- "wasm-bindgen-cli",
 ]
 
 [[package]]
@@ -2723,6 +2722,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-cli-bin"
+version = "0.0.0"
+dependencies = [
+ "wasm-bindgen-cli",
+]
+
+[[package]]
 name = "wasm-bindgen-cli-support"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,9 +2865,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "pgpvis-core",
+    "wasm-bindgen-cli",
 ]
 
 [profile.release]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "bootstrap": "pnpm -F pgpvis-core dist:wasm-bindgen && pnpm -F pgpvis-ui bootstrap",
+    "bootstrap": "cargo check -p wasm-bindgen-cli-bin --release && pnpm -F pgpvis-ui bootstrap",
     "lint": "editorconfig-checker && pnpm -F 'pgpvis-*' lint",
     "test": "pnpm -F 'pgpvis-*' test",
     "dist": "pnpm -F pgpvis-ui dist",

--- a/pgpvis-core/Cargo.toml
+++ b/pgpvis-core/Cargo.toml
@@ -19,11 +19,5 @@ wasm-bindgen = "0.2.100"
 [dev-dependencies]
 insta = { version = "1.42.2", features = ["yaml"] }
 
-[build-dependencies]
-wasm-bindgen-cli = { version = "0.2.100", artifact = ["bin:wasm-bindgen"], optional = true }
-
-[features]
-wasm-bindgen-cli = ["dep:wasm-bindgen-cli"]
-
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-O"]

--- a/pgpvis-core/package.json
+++ b/pgpvis-core/package.json
@@ -3,8 +3,7 @@
   "private": true,
   "scripts": {
     "lint": "cargo fmt --check && cargo clippy",
-    "test": "cargo test",
-    "dist:wasm-bindgen": "cargo build --release --features wasm-bindgen-cli"
+    "test": "cargo test"
   },
   "packageManager": "pnpm@10.9.0+sha512.0486e394640d3c1fb3c9d43d49cf92879ff74f8516959c235308f5a8f62e2e19528a65cdc2a3058f587cde71eba3d5b56327c8c33a97e4c4051ca48a10ca2d5f"
 }

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -27,7 +27,8 @@ echo "============================================================"
 
 mkdir -p "$dist_dir"
 pnpm clean
-pnpm -F pgpvis-core dist:wasm-bindgen
+# Build `wasm-bindgen-cli`
+cargo check -p wasm-bindgen-cli-bin --release
 VITE_PGPVIS_VERSION="$version" pnpm dist
 
 echo "============================================================"

--- a/wasm-bindgen-cli/Cargo.toml
+++ b/wasm-bindgen-cli/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "wasm-bindgen-cli-bin"
+edition = "2021"
+publish = false
+
+[build-dependencies]
+wasm-bindgen-cli = { version = "0.2.100", artifact = ["bin:wasm-bindgen"] }

--- a/wasm-bindgen-cli/README.md
+++ b/wasm-bindgen-cli/README.md
@@ -1,0 +1,4 @@
+This directory is a shim crate which builds and makes `wasm-bindgen-cli`'s
+artifact `wasm-bindgen` availble in the workspace `target` directory.
+
+Build by invoking either `cargo check -r` or `cargo build -r`.

--- a/wasm-bindgen-cli/build.rs
+++ b/wasm-bindgen-cli/build.rs
@@ -1,4 +1,3 @@
-#[cfg(all(feature = "wasm-bindgen-cli", not(target_family = "wasm")))]
 fn main() {
     use std::path::Path;
 
@@ -12,6 +11,3 @@ fn main() {
     };
     std::fs::copy(wasm_bindgen_dir, target_dir.join("wasm-bindgen")).unwrap();
 }
-
-#[cfg(any(not(feature = "wasm-bindgen-cli"), target_family = "wasm"))]
-fn main() {}


### PR DESCRIPTION
Dependabot cannot handle `Cargo.toml` with `bindeps`-related entries, so we have to extract those options into a seperate manifest and make Dependabot ignore it.

Besides being a workaround, this also makes the package structure better organized.